### PR TITLE
update range of allowable dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dynamic = ["version"]
 description = "Python wrapper for FRC Team 6328's URCL library"
 license = "MIT"
 dependencies = [
-    "wpilib~=2026.1.1",
+    "wpilib>=2026.1.1,<2027",
 ]
 
 [[project.authors]]


### PR DESCRIPTION
```
 ~/git/pysysid  update_deps *1 !1  uv sync                                               1 х  5s
warning: The `tool.uv.dev-dependencies` field (used in `pyproject.toml`) is deprecated and will be removed in a future release; use `dependency-groups.dev` instead
  × No solution found when resolving dependencies:
  ╰─▶ Because robotpy==2026.2.1 depends on wpilib==2026.2.1 and robotpy-urcl==2026.0.0
      depends on wpilib>=2026.1.1,<2026.2.dev0, we can conclude that robotpy==2026.2.1 and
      robotpy-urcl==2026.0.0 are incompatible.
      And because only robotpy-urcl<=2026.0.0 is available, we can conclude that
      robotpy==2026.2.1 and robotpy-urcl>=2026.0.0 are incompatible.
      And because your project depends on robotpy==2026.2.1 and robotpy-urcl>=2026.0.0, we can
      conclude that your project's requirements are unsatisfiable.

```

new wpilib version out which I think should be supported